### PR TITLE
Improve public API

### DIFF
--- a/docs/Faithlife.Diff/DiffUtility/FindDifferences.md
+++ b/docs/Faithlife.Diff/DiffUtility/FindDifferences.md
@@ -3,14 +3,14 @@
 Finds the differences between the two lists.
 
 ```csharp
-public static IEnumerable<ValueTuple<IndexRange, IndexRange>> FindDifferences<T>(IList<T> listFirst, IList<T> listSecond)
+public static IReadOnlyList<ValueTuple<IndexRange, IndexRange>> FindDifferences<T>(IReadOnlyList<T> first, IReadOnlyList<T> second)
 ```
 
 | parameter | description |
 | --- | --- |
 | T | The type of item in the lists. |
-| listFirst | The first list. |
-| listSecond | The second list. |
+| first | The first list. |
+| second | The second list. |
 
 ## Return Value
 
@@ -35,15 +35,15 @@ EqualityComparer&lt;T&gt;.Default is used to compare items.
 Finds the differences between the two lists.
 
 ```csharp
-public static IEnumerable<ValueTuple<IndexRange, IndexRange>> FindDifferences<T>(IList<T> listFirst, 
-    IList<T> listSecond, IEqualityComparer<T> comparer)
+public static IReadOnlyList<ValueTuple<IndexRange, IndexRange>> FindDifferences<T>(IReadOnlyList<T> first, 
+    IReadOnlyList<T> second, IEqualityComparer<T> comparer)
 ```
 
 | parameter | description |
 | --- | --- |
 | T | The type of item in the lists. |
-| listFirst | The first list. |
-| listSecond | The second list. |
+| first | The first list. |
+| second | The second list. |
 | comparer | The comparer. |
 
 ## Return Value

--- a/src/Faithlife.Diff/Faithlife.Diff.csproj
+++ b/src/Faithlife.Diff/Faithlife.Diff.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>0.1.0</Version>
-    <TargetFrameworks>netstandard1.4;netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard2.0;net46</TargetFrameworks>
     <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net46' and '$(MONO_ROOT)' != ''">$(MONO_ROOT)/lib/mono/4.6-api/</FrameworkPathOverride>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>

--- a/tests/Faithlife.Diff.Tests/DiffUtilityTests.cs
+++ b/tests/Faithlife.Diff.Tests/DiffUtilityTests.cs
@@ -10,269 +10,153 @@ namespace Faithlife.Diff.Tests
 		[Test]
 		public void DifferenceFirstNull()
 		{
-			Assert.Throws<ArgumentNullException>(() => DiffUtility.FindDifferences(null, new int[] { 1, 2, 3 }));
+			Assert.Throws<ArgumentNullException>(() => DiffUtility.FindDifferences(null, new[] { 1, 2, 3 }));
 		}
 
 		[Test]
 		public void DifferenceFirstSecond()
 		{
-			Assert.Throws<ArgumentNullException>(() => DiffUtility.FindDifferences(new int[] { 1, 2, 3 }, null));
+			Assert.Throws<ArgumentNullException>(() => DiffUtility.FindDifferences(new[] { 1, 2, 3 }, null));
 		}
 
 		[Test]
 		public void IntegerListDeleteDifference()
 		{
-			List<int> listFirst = new List<int>();
-			listFirst.Add(1);
-			listFirst.Add(2);
-			listFirst.Add(3);
+			var difference = DiffUtility.FindDifferences(new[] { 1, 2, 3 }, new[] { 1, 3 });
 
-			List<int> listSecond = new List<int>();
-			listSecond.Add(1);
-			listSecond.Add(3);
-
-			List<ValueTuple<IndexRange, IndexRange>> listDifference = new List<ValueTuple<IndexRange, IndexRange>>(DiffUtility.FindDifferences(listFirst, listSecond));
-
-			Assert.AreEqual(1, listDifference.Count);
-			Assert.AreEqual(listDifference[0], new ValueTuple<IndexRange, IndexRange>(new IndexRange(1, 1), new IndexRange(1, 0)));
+			Assert.AreEqual(1, difference.Count);
+			Assert.AreEqual(difference[0], (new IndexRange(1, 1), new IndexRange(1, 0)));
 		}
 
 		[Test]
 		public void IntegerListInsertDifference()
 		{
-			List<int> listFirst = new List<int>();
-			listFirst.Add(1);
-			listFirst.Add(3);
+			var difference = DiffUtility.FindDifferences(new[] { 1, 3 }, new[] { 1, 2, 3 });
 
-			List<int> listSecond = new List<int>();
-			listSecond.Add(1);
-			listSecond.Add(2);
-			listSecond.Add(3);
-
-			List<ValueTuple<IndexRange, IndexRange>> listDifference = new List<ValueTuple<IndexRange, IndexRange>>(DiffUtility.FindDifferences(listFirst, listSecond));
-
-			Assert.AreEqual(1, listDifference.Count);
-			Assert.AreEqual(listDifference[0], new ValueTuple<IndexRange, IndexRange>(new IndexRange(1, 0), new IndexRange(1, 1)));
+			Assert.AreEqual(1, difference.Count);
+			Assert.AreEqual(difference[0], (new IndexRange(1, 0), new IndexRange(1, 1)));
 		}
 
 		[Test]
 		public void IntegerListChangeDifference()
 		{
-			List<int> listFirst = new List<int>();
-			listFirst.Add(1);
-			listFirst.Add(4);
-			listFirst.Add(3);
+			var difference = DiffUtility.FindDifferences(new[] { 1, 4, 3 }, new[] { 1, 2, 3 });
 
-			List<int> listSecond = new List<int>();
-			listSecond.Add(1);
-			listSecond.Add(2);
-			listSecond.Add(3);
-
-			List<ValueTuple<IndexRange, IndexRange>> listDifference = new List<ValueTuple<IndexRange, IndexRange>>(DiffUtility.FindDifferences(listFirst, listSecond));
-
-			Assert.AreEqual(1, listDifference.Count);
-			Assert.AreEqual(listDifference[0], new ValueTuple<IndexRange, IndexRange>(new IndexRange(1, 1), new IndexRange(1, 1)));
+			Assert.AreEqual(1, difference.Count);
+			Assert.AreEqual(difference[0], (new IndexRange(1, 1), new IndexRange(1, 1)));
 		}
 
 		[Test]
 		public void IntegerListChangeDifferenceTwo()
 		{
-			List<int> listFirst = new List<int>();
-			listFirst.Add(1);
-			listFirst.Add(4);
-			listFirst.Add(3);
+			var difference = DiffUtility.FindDifferences(new[] { 1, 4, 3 }, new[] { 1, 2, 2, 3 });
 
-			List<int> listSecond = new List<int>();
-			listSecond.Add(1);
-			listSecond.Add(2);
-			listSecond.Add(2);
-			listSecond.Add(3);
-
-			List<ValueTuple<IndexRange, IndexRange>> listDifference = new List<ValueTuple<IndexRange, IndexRange>>(DiffUtility.FindDifferences(listFirst, listSecond));
-
-			Assert.AreEqual(1, listDifference.Count);
-			Assert.AreEqual(listDifference[0], new ValueTuple<IndexRange, IndexRange>(new IndexRange(1, 1), new IndexRange(1, 2)));
+			Assert.AreEqual(1, difference.Count);
+			Assert.AreEqual(difference[0], (new IndexRange(1, 1), new IndexRange(1, 2)));
 		}
 
 		[Test]
 		public void IntegerListChangeDifferenceThree()
 		{
-			List<int> listFirst = new List<int>();
-			listFirst.Add(1);
-			listFirst.Add(4);
-			listFirst.Add(3);
+			var difference = DiffUtility.FindDifferences(new[] { 1, 4, 3 }, new[] { 1, 2, 2, 2, 3 });
 
-			List<int> listSecond = new List<int>();
-			listSecond.Add(1);
-			listSecond.Add(2);
-			listSecond.Add(2);
-			listSecond.Add(2);
-			listSecond.Add(3);
-
-			List<ValueTuple<IndexRange, IndexRange>> listDifference = new List<ValueTuple<IndexRange, IndexRange>>(DiffUtility.FindDifferences(listFirst, listSecond));
-
-			Assert.AreEqual(1, listDifference.Count);
-			Assert.AreEqual(listDifference[0], new ValueTuple<IndexRange, IndexRange>(new IndexRange(1, 1), new IndexRange(1, 3)));
+			Assert.AreEqual(1, difference.Count);
+			Assert.AreEqual(difference[0], (new IndexRange(1, 1), new IndexRange(1, 3)));
 		}
 
 		[Test]
 		public void IntegerListChangeDifferenceFour()
 		{
-			List<int> listFirst = new List<int>();
-			listFirst.Add(1);
-			listFirst.Add(4);
-			listFirst.Add(4);
-			listFirst.Add(3);
+			var difference = DiffUtility.FindDifferences(new[] { 1, 4, 4, 3 }, new[] { 1, 2, 2, 2, 3 });
 
-			List<int> listSecond = new List<int>();
-			listSecond.Add(1);
-			listSecond.Add(2);
-			listSecond.Add(2);
-			listSecond.Add(2);
-			listSecond.Add(3);
-
-			List<ValueTuple<IndexRange, IndexRange>> listDifference = new List<ValueTuple<IndexRange, IndexRange>>(DiffUtility.FindDifferences(listFirst, listSecond));
-
-			Assert.AreEqual(1, listDifference.Count);
-			Assert.AreEqual(listDifference[0], new ValueTuple<IndexRange, IndexRange>(new IndexRange(1, 2), new IndexRange(1, 3)));
+			Assert.AreEqual(1, difference.Count);
+			Assert.AreEqual(difference[0], (new IndexRange(1, 2), new IndexRange(1, 3)));
 		}
 
 		[Test]
 		public void IntegerListChangeDifferenceFive()
 		{
-			List<int> listFirst = new List<int>();
-			listFirst.Add(1);
-			listFirst.Add(4);
-			listFirst.Add(4);
-			listFirst.Add(4);
-			listFirst.Add(4);
-			listFirst.Add(3);
+			var first = new[] { 1, 4, 4, 4, 4, 3 };
+			var second = new[] { 1, 2, 2, 2, 3 };
 
-			List<int> listSecond = new List<int>();
-			listSecond.Add(1);
-			listSecond.Add(2);
-			listSecond.Add(2);
-			listSecond.Add(2);
-			listSecond.Add(3);
+			var difference = DiffUtility.FindDifferences(first, second);
 
-			List<ValueTuple<IndexRange, IndexRange>> listDifference = new List<ValueTuple<IndexRange, IndexRange>>(DiffUtility.FindDifferences(listFirst, listSecond));
-
-			Assert.AreEqual(1, listDifference.Count);
-			Assert.AreEqual(listDifference[0], new ValueTuple<IndexRange, IndexRange>(new IndexRange(1, 4), new IndexRange(1, 3)));
+			Assert.AreEqual(1, difference.Count);
+			Assert.AreEqual(difference[0], (new IndexRange(1, 4), new IndexRange(1, 3)));
 		}
 
 		[Test]
 		public void StringListChangeDifference()
 		{
-			List<string> listFirst = new List<string>();
-			listFirst.Add("1");
-			listFirst.Add("4");
-			listFirst.Add("4");
-			listFirst.Add("4");
-			listFirst.Add("4");
-			listFirst.Add("3");
+			var first = new[] { "1", "4", "4", "4", "4", "3" };
+			var second = new[] { "1", "2", "2", "2", "3" };
 
-			List<string> listSecond = new List<string>();
-			listSecond.Add("1");
-			listSecond.Add("2");
-			listSecond.Add("2");
-			listSecond.Add("2");
-			listSecond.Add("3");
+			var difference = DiffUtility.FindDifferences(first, second);
 
-			List<ValueTuple<IndexRange, IndexRange>> listDifference = new List<ValueTuple<IndexRange, IndexRange>>(DiffUtility.FindDifferences(listFirst, listSecond));
-
-			Assert.AreEqual(1, listDifference.Count);
-			Assert.AreEqual(listDifference[0], new ValueTuple<IndexRange, IndexRange>(new IndexRange(1, 4), new IndexRange(1, 3)));
+			Assert.AreEqual(1, difference.Count);
+			Assert.AreEqual(difference[0], (new IndexRange(1, 4), new IndexRange(1, 3)));
 		}
 
 		[Test]
 		public void StringListChangeDifferenceTwo()
 		{
-			List<string> listFirst = new List<string>();
-			listFirst.Add("one");
-			listFirst.Add("Two");
-			listFirst.Add("three");
-			listFirst.Add("four");
-			listFirst.Add("five");
-			listFirst.Add("Six");
+			var first = new[] { "one", "Two", "three", "four", "five", "Six" };
+			var second = new[] { "one", "two", "Three", "Four", "Six" };
 
-			List<string> listSecond = new List<string>();
-			listSecond.Add("one");
-			listSecond.Add("two");
-			listSecond.Add("Three");
-			listSecond.Add("Four");
-			listSecond.Add("Six");
-
-			List<ValueTuple<IndexRange, IndexRange>> listDifference = new List<ValueTuple<IndexRange, IndexRange>>(DiffUtility.FindDifferences(listFirst, listSecond));
-			Assert.AreEqual(1, listDifference.Count);
-			Assert.AreEqual(listDifference[0], new ValueTuple<IndexRange, IndexRange>(new IndexRange(1, 4), new IndexRange(1, 3)));
+			var difference = DiffUtility.FindDifferences(first, second);
+			Assert.AreEqual(1, difference.Count);
+			Assert.AreEqual(difference[0], (new IndexRange(1, 4), new IndexRange(1, 3)));
 		}
 
 		public static IEnumerable<StringDifference> StringDifferenceTests()
 		{
 			// test one
-			StringDifference diff1 = new StringDifference();
-			diff1.First = "This is a test";
-			diff1.Second = "This is test";
-			diff1.Changes = new List<ValueTuple<IndexRange, IndexRange>>(new[] {
-					new ValueTuple<IndexRange, IndexRange>(new IndexRange(2, 1), new IndexRange(2, 0))
-				});
+			var diff1 = new StringDifference
+			{
+				First = "This is a test",
+				Second = "This is test",
+				Changes = new List<ValueTuple<IndexRange, IndexRange>>
+				{
+					(new IndexRange(2, 1), new IndexRange(2, 0))
+				},
+			};
 			yield return diff1;
 
 			// test two
-			StringDifference diff2 = new StringDifference();
-			diff2.First = "This is test a";
-			diff2.Second = "This is a test";
-			diff2.Changes = new List<ValueTuple<IndexRange, IndexRange>>(new[] {
-					new ValueTuple<IndexRange, IndexRange>(new IndexRange(2, 0), new IndexRange(2, 1)),
-					new ValueTuple<IndexRange, IndexRange>(new IndexRange(3, 1), new IndexRange(4, 0))
-				});
+			var diff2 = new StringDifference
+			{
+				First = "This is test a",
+				Second = "This is a test",
+				Changes = new List<ValueTuple<IndexRange, IndexRange>>
+				{
+					(new IndexRange(2, 0), new IndexRange(2, 1)),
+					(new IndexRange(3, 1), new IndexRange(4, 0))
+				},
+			};
 			yield return diff2;
 
 			// test three
-			StringDifference diff3 = new StringDifference();
-			diff3.First = "This is a test";
-			diff3.Second = "This is test a";
-			diff3.Changes = new List<ValueTuple<IndexRange, IndexRange>>(new[] {
-					new ValueTuple<IndexRange, IndexRange>(new IndexRange(2, 0), new IndexRange(2, 1)),
-					new ValueTuple<IndexRange, IndexRange>(new IndexRange(3, 1), new IndexRange(4, 0))
-				});
+			var diff3 = new StringDifference
+			{
+				First = "This is a test",
+				Second = "This is test a",
+				Changes = new List<ValueTuple<IndexRange, IndexRange>>
+				{
+					(new IndexRange(2, 0), new IndexRange(2, 1)),
+					(new IndexRange(3, 1), new IndexRange(4, 0))
+				},
+			};
 			yield return diff3;
 		}
 
-		[TestCaseSource("StringDifferenceTests")]
+		[TestCaseSource(nameof(StringDifferenceTests))]
 		public void StringListChangeDifferenceTwo(StringDifference difference)
 		{
-			List<string> listFirst = new List<string>(difference.First.Split(' '));
-			List<string> listSecond = new List<string>(difference.Second.Split(' '));
+			var first = difference.First.Split(' ');
+			var second = difference.Second.Split(' ');
 
-			List<ValueTuple<IndexRange, IndexRange>> listDifference = new List<ValueTuple<IndexRange, IndexRange>>(DiffUtility.FindDifferences(listFirst, listSecond));
-
-			CollectionAssert.AreEqual(difference.Changes, listDifference);
-		}
-
-		[Test]
-		public void ListDifferenceEquality()
-		{
-			ValueTuple<IndexRange, IndexRange> ld1111 = new ValueTuple<IndexRange, IndexRange>(new IndexRange(1, 1), new IndexRange(1, 1));
-			ValueTuple<IndexRange, IndexRange> ld1111b = new ValueTuple<IndexRange, IndexRange>(new IndexRange(1, 1), new IndexRange(1, 1));
-			ValueTuple<IndexRange, IndexRange> ld1112 = new ValueTuple<IndexRange, IndexRange>(new IndexRange(1, 1), new IndexRange(1, 2));
-			ValueTuple<IndexRange, IndexRange> ld2111 = new ValueTuple<IndexRange, IndexRange>(new IndexRange(2, 1), new IndexRange(1, 1));
-
-			Assert.IsTrue(ld1111.Equals(ld1111b));
-			Assert.IsTrue(ld1111.Equals((object) ld1111b));
-			Assert.IsFalse(ld1111.Equals((object) null));
-			Assert.IsFalse(ld1111.Equals(ld1112));
-			Assert.IsFalse(ld1111.Equals((object) ld1112));
-			Assert.IsTrue(ld1111.GetHashCode() == ld1111b.GetHashCode());
-
-			// TODO: okay to remove these?
-			//Assert.IsTrue(ld1111 == ld1111b);
-			//Assert.IsTrue(ld1111 != ld1112);
-			//Assert.IsTrue(ld1111 != ld2111);
-			//Assert.IsFalse(ld1111 == ld1112);
-			//Assert.IsFalse(ld1111 == ld2111);
-			//Assert.IsFalse(ld1111 != ld1111b);
+			var result = DiffUtility.FindDifferences(first, second);
+			CollectionAssert.AreEqual(difference.Changes, result);
 		}
 
 		public struct StringDifference


### PR DESCRIPTION
* Return `IReadOnlyList` so the caller knows the result isn't lazy.
* Name the items in the returned tuples.

I didn't change the input parameters from `IList<T>` to `ICollection<T>` or `IEnumerable<T>` because the returned tuples assume the ability to index into the lists, so the caller should already have a non-lazy, indexable collection.

I want to stabilise the API for v1.0 so it can be used by JsonPatch in Faithlife.Json.